### PR TITLE
Fix build for newer systems.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 GIT_VERSION := $(shell git describe --abbrev=6 --dirty --always --tags)
 E2FSPROGS_LIB = e2fsprogs/lib
 SERIALPORT = libserialport
-CFLAGS = -std=gnu99 -Wall -Werror -Wno-error=deprecated-declarations -DGIT_VERSION=\"$(GIT_VERSION)\" \
+CFLAGS = -std=gnu99 -Wall -Werror -Wno-error=deprecated-declarations -Wno-error=restrict -DGIT_VERSION=\"$(GIT_VERSION)\" \
 		 -I. -I$(E2FSPROGS_LIB) -I$(SERIALPORT)
 LDLIBS = -lpthread
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 GIT_VERSION := $(shell git describe --abbrev=6 --dirty --always --tags)
 E2FSPROGS_LIB = e2fsprogs/lib
 SERIALPORT = libserialport
-CFLAGS = -std=gnu99 -Wall -Werror -DGIT_VERSION=\"$(GIT_VERSION)\" \
+CFLAGS = -std=gnu99 -Wall -Werror -Wno-error=deprecated-declarations -DGIT_VERSION=\"$(GIT_VERSION)\" \
 		 -I. -I$(E2FSPROGS_LIB) -I$(SERIALPORT)
 LDLIBS = -lpthread
 


### PR DESCRIPTION
There was some changes in the newer compilers and libs.

This fixes warnings during build treated as critical until someone from upstream
https://sigrok.org/gitweb/?p=libserialport.git
is willing to rewrite the code to follow new compilers tips.
